### PR TITLE
Fix new relic home directory path

### DIFF
--- a/8-chiseled/Dockerfile
+++ b/8-chiseled/Dockerfile
@@ -18,5 +18,5 @@ ENV NEW_RELIC_DISTRIBUTED_TRACING_ENABLED true
 # This variable enables New Relic (disabled by default)
 ENV CORECLR_ENABLE_PROFILING 0
 
-COPY --from=build /usr/local/newrelic-dotnet-agent /usr/local/
+COPY --from=build /usr/local/newrelic-dotnet-agent/ /usr/local/newrelic-dotnet-agent/
 COPY --from=build /usr/bin/sleep /usr/bin/

--- a/9-chiseled/Dockerfile
+++ b/9-chiseled/Dockerfile
@@ -18,5 +18,5 @@ ENV NEW_RELIC_DISTRIBUTED_TRACING_ENABLED true
 # This variable enables New Relic (disabled by default)
 ENV CORECLR_ENABLE_PROFILING 0
 
-COPY --from=build /usr/local/newrelic-dotnet-agent /usr/local/
+COPY --from=build /usr/local/newrelic-dotnet-agent/ /usr/local/newrelic-dotnet-agent/
 COPY --from=build /usr/bin/sleep /usr/bin/


### PR DESCRIPTION
Files in new relic agent home directory went to wrong dir. Add slash to show we're copying a dir.